### PR TITLE
Render case investigation summary as markdown + stronger JSON delimiter repair

### DIFF
--- a/aml-backend/services/llm/streaming_classification_service.py
+++ b/aml-backend/services/llm/streaming_classification_service.py
@@ -665,13 +665,19 @@ Provide JSON with: risk_level, risk_score, recommended_action."""
                 except json.JSONDecodeError as repair_err:
                     logger.warning(
                         f"Repaired JSON still invalid ({repair_err.msg} at pos {repair_err.pos}); "
-                        "attempting truncated-prefix parse"
+                        "attempting position-driven delimiter repair"
                     )
-                    truncated = self._truncate_to_valid_json(repaired)
-                    if truncated is None:
-                        raise repair_err
-                    parsed_result = json.loads(truncated)
-                    logger.info("JSON parsed successfully from truncated prefix")
+                    delim_fixed = self._fix_delimiters_iteratively(repaired)
+                    if delim_fixed is not None:
+                        parsed_result = json.loads(delim_fixed)
+                        logger.info("JSON parsed successfully after iterative delimiter repair")
+                    else:
+                        logger.warning("Delimiter repair failed; attempting truncated-prefix parse")
+                        truncated = self._truncate_to_valid_json(repaired)
+                        if truncated is None:
+                            raise repair_err
+                        parsed_result = json.loads(truncated)
+                        logger.info("JSON parsed successfully from truncated prefix")
             
             # Validate and structure the result with comprehensive defaults
             structured_result = self._structure_classification_result(
@@ -779,6 +785,46 @@ Provide JSON with: risk_level, risk_score, recommended_action."""
         # Strip trailing commas again post-repair
         repaired = re.sub(r',(\s*[}\]])', r'\1', repaired)
         return repaired
+
+    def _fix_delimiters_iteratively(self, json_text: str, max_iterations: int = 25) -> Optional[str]:
+        """
+        Repeatedly attempt to parse, and on each `Expecting ',' delimiter` or
+        `Expecting ':' delimiter` error, insert the missing delimiter at the
+        exact position reported by the Python JSON decoder. Returns the repaired
+        string if parse eventually succeeds, else None.
+
+        This handles cases the regex-based repair misses (e.g. missing commas with
+        no newline between fields, or unusual whitespace patterns), because the
+        decoder itself tells us the offending offset.
+        """
+        text = json_text
+        for _ in range(max_iterations):
+            try:
+                json.loads(text)
+                return text
+            except json.JSONDecodeError as e:
+                msg = e.msg or ''
+                pos = e.pos
+                if 'delimiter' in msg and "','" in msg and 0 <= pos <= len(text):
+                    # Walk backward over whitespace and insert a comma after the prior token
+                    insert_at = pos
+                    while insert_at > 0 and text[insert_at - 1] in ' \t\r\n':
+                        insert_at -= 1
+                    if insert_at == 0 or text[insert_at - 1] == ',':
+                        return None
+                    text = text[:insert_at] + ',' + text[insert_at:]
+                    continue
+                if 'delimiter' in msg and "':'" in msg and 0 <= pos <= len(text):
+                    insert_at = pos
+                    while insert_at > 0 and text[insert_at - 1] in ' \t\r\n':
+                        insert_at -= 1
+                    if insert_at == 0 or text[insert_at - 1] == ':':
+                        return None
+                    text = text[:insert_at] + ':' + text[insert_at:]
+                    continue
+                # Unknown error class — give up so the caller can try other strategies
+                return None
+        return None
 
     def _truncate_to_valid_json(self, json_text: str) -> Optional[str]:
         """

--- a/frontend/components/entityResolution/enhanced/CaseInvestigationDisplay.jsx
+++ b/frontend/components/entityResolution/enhanced/CaseInvestigationDisplay.jsx
@@ -18,6 +18,78 @@ import { Code } from '@leafygreen-ui/code';
 import Callout from '@leafygreen-ui/callout';
 import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const markdownComponents = {
+  h1: ({ children }) => (
+    <H3 style={{ fontSize: '15px', marginTop: spacing[3], marginBottom: spacing[2] }}>{children}</H3>
+  ),
+  h2: ({ children }) => (
+    <H3 style={{ fontSize: '14px', marginTop: spacing[3], marginBottom: spacing[2] }}>{children}</H3>
+  ),
+  h3: ({ children }) => (
+    <Body style={{ fontSize: '13px', fontWeight: 600, marginTop: spacing[2], marginBottom: spacing[1] }}>
+      {children}
+    </Body>
+  ),
+  p: ({ children }) => (
+    <Body style={{ fontSize: '12px', lineHeight: 1.6, marginBottom: spacing[2] }}>{children}</Body>
+  ),
+  ul: ({ children }) => (
+    <ul style={{ fontSize: '12px', lineHeight: 1.6, paddingLeft: spacing[4], marginBottom: spacing[2] }}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol style={{ fontSize: '12px', lineHeight: 1.6, paddingLeft: spacing[4], marginBottom: spacing[2] }}>
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li style={{ marginBottom: spacing[1] }}>{children}</li>,
+  strong: ({ children }) => <strong style={{ fontWeight: 600 }}>{children}</strong>,
+  em: ({ children }) => <em>{children}</em>,
+  code: ({ inline, children }) =>
+    inline ? (
+      <code
+        style={{
+          fontFamily: 'monospace',
+          backgroundColor: palette.gray.light2,
+          padding: '1px 4px',
+          borderRadius: 3,
+          fontSize: '11px',
+        }}
+      >
+        {children}
+      </code>
+    ) : (
+      <pre
+        style={{
+          fontFamily: 'monospace',
+          backgroundColor: palette.gray.light2,
+          padding: spacing[2],
+          borderRadius: 4,
+          fontSize: '11px',
+          overflowX: 'auto',
+        }}
+      >
+        <code>{children}</code>
+      </pre>
+    ),
+  table: ({ children }) => (
+    <table style={{ borderCollapse: 'collapse', fontSize: '12px', marginBottom: spacing[2] }}>
+      {children}
+    </table>
+  ),
+  th: ({ children }) => (
+    <th style={{ border: `1px solid ${palette.gray.light1}`, padding: spacing[1], textAlign: 'left' }}>
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td style={{ border: `1px solid ${palette.gray.light1}`, padding: spacing[1] }}>{children}</td>
+  ),
+};
 
 /**
  * Executive Summary Tab - High-level case overview
@@ -117,18 +189,16 @@ function ExecutiveSummaryTab({ workflowData, investigation }) {
       {investigation?.investigation_summary && (
         <Card style={{ padding: spacing[4] }}>
           <H3 style={{ marginBottom: spacing[2], fontSize: '16px' }}>Investigation Summary</H3>
-          <Card style={{ 
+          <Card style={{
             padding: spacing[3],
             backgroundColor: palette.gray.light3,
             border: `1px solid ${palette.gray.light1}`
           }}>
-            <Body style={{ 
-              lineHeight: 1.6, 
-              whiteSpace: 'pre-wrap',
-              fontSize: '12px'
-            }}>
-              {investigation.investigation_summary}
-            </Body>
+            <div style={{ fontSize: '12px', lineHeight: 1.6 }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                {investigation.investigation_summary}
+              </ReactMarkdown>
+            </div>
           </Card>
         </Card>
       )}

--- a/frontend/components/entityResolution/enhanced/DeepInvestigationWorkbench.jsx
+++ b/frontend/components/entityResolution/enhanced/DeepInvestigationWorkbench.jsx
@@ -12,6 +12,37 @@ import Code from '@leafygreen-ui/code';
 import ExpandableCard from '@leafygreen-ui/expandable-card';
 import { palette } from '@leafygreen-ui/palette';
 import { spacing } from '@leafygreen-ui/tokens';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const summaryMarkdownComponents = {
+  h1: ({ children }) => (
+    <H3 style={{ fontSize: '15px', marginTop: spacing[3], marginBottom: spacing[2] }}>{children}</H3>
+  ),
+  h2: ({ children }) => (
+    <H3 style={{ fontSize: '14px', marginTop: spacing[3], marginBottom: spacing[2] }}>{children}</H3>
+  ),
+  h3: ({ children }) => (
+    <Body style={{ fontSize: '13px', fontWeight: 600, marginTop: spacing[2], marginBottom: spacing[1] }}>
+      {children}
+    </Body>
+  ),
+  p: ({ children }) => (
+    <Body style={{ fontSize: '13px', lineHeight: 1.5, marginBottom: spacing[2] }}>{children}</Body>
+  ),
+  ul: ({ children }) => (
+    <ul style={{ fontSize: '13px', lineHeight: 1.5, paddingLeft: spacing[4], marginBottom: spacing[2] }}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol style={{ fontSize: '13px', lineHeight: 1.5, paddingLeft: spacing[4], marginBottom: spacing[2] }}>
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li style={{ marginBottom: spacing[1] }}>{children}</li>,
+  strong: ({ children }) => <strong style={{ fontWeight: 600 }}>{children}</strong>,
+};
 
 /**
  * Deep Investigation Workbench
@@ -109,14 +140,16 @@ function DeepInvestigationWorkbench({ investigation, workflowData, onReset }) {
           </div>
 
           {investigationReport.executiveSummary && (
-            <Card style={{ 
+            <Card style={{
               padding: spacing[3],
               backgroundColor: 'rgba(255, 255, 255, 0.8)',
               border: '1px solid #E5E7EB'
             }}>
-              <Body style={{ fontSize: '13px', lineHeight: '1.5' }}>
-                {investigationReport.executiveSummary}
-              </Body>
+              <div style={{ fontSize: '13px', lineHeight: 1.5 }}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={summaryMarkdownComponents}>
+                  {investigationReport.executiveSummary}
+                </ReactMarkdown>
+              </div>
             </Card>
           )}
         </Card>


### PR DESCRIPTION
## Summary

Follow-up to #40. Two related fixes:

### 1. Investigation summary rendered as markdown
The Case Investigation Summary the LLM returns is markdown (`# CASE INVESTIGATION SUMMARY`, `**EXECUTIVE OVERVIEW**`, bullet lists), but the UI was rendering it as plain text inside `<Body whiteSpace="pre-wrap">`, so users saw raw `#` and `**` characters instead of headers and bold.

Now rendered with `react-markdown` + `remark-gfm` (already in `package.json`), styled to match LeafyGreen typography:
- `CaseInvestigationDisplay.jsx` — Investigation Summary card
- `DeepInvestigationWorkbench.jsx` — Executive Summary card

### 2. Position-driven JSON delimiter repair
The repair landed in #40 used a newline-based regex to insert missing commas. That missed same-line cases — e.g. `{"a": "x" "b": "y"}` — so classification still occasionally fell back to "manual review required".

Adds `_fix_delimiters_iteratively`: reads the `JSONDecodeError`'s reported position and surgically inserts the missing `,` or `:` at that exact offset, looping until the document parses or we hit a cap. Slots in between the regex repair and the truncated-prefix fallback.

Verified against same-line missing-comma, missing-colon, and multi-error cases — all recover.

## Test plan
- [x] Unit-verified iterative repair against six common LLM JSON failure modes
- [x] JSX files parse cleanly
- [ ] Restart `aml-backend`, reload frontend, re-run entity-resolution classification end-to-end; confirm Investigation Summary renders formatted (headers/bold) and no fallback parse errors